### PR TITLE
added in audio splitter

### DIFF
--- a/Mac/split_audio_file_into_multiples.sh
+++ b/Mac/split_audio_file_into_multiples.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+INPUT_FILE="input.mp3"
+TIMESTAMP_FILE="timestamps.txt"
+
+while IFS= read -r line; do
+    start=$(echo "$line" | awk '{print $1}')
+    end=$(echo "$line" | awk '{print $2}')
+    output=$(echo "$line" | awk '{print $3}')
+    
+    ffmpeg -i "$INPUT_FILE" -ss "$start" -to "$end" -c copy "$output"
+done < "$TIMESTAMP_FILE"

--- a/Mac/timestamps.txt
+++ b/Mac/timestamps.txt
@@ -1,0 +1,2 @@
+00:00:00 23:59:59 name.mp3
+# leave a trailing line


### PR DESCRIPTION
# Overview

Adds a simple script that uses `ffmpeg` to break an audio file into multiple audio files based on timestamps.