### PR TITLE
Js add video splitter

### DIFF
--- a/Mac/split_audio_file_into_multiples.sh
+++ b/Mac/split_audio_file_into_multiples.sh
@@ -1,7 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-INPUT_FILE="input.mp3"
-TIMESTAMP_FILE="timestamps.txt"
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <input_file> <timestamp_file>"
+    exit 1
+fi
+
+INPUT_FILE="$1"
+TIMESTAMP_FILE="$2"
 
 while IFS= read -r line; do
     start=$(echo "$line" | awk '{print $1}')

--- a/Mac/split_video_file_into_multiples.sh
+++ b/Mac/split_video_file_into_multiples.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <input_file> <timestamp_file>"
+    exit 1
+fi
+
+INPUT_FILE="$1"
+TIMESTAMP_FILE="$2"
+
+while IFS= read -r line; do
+    start=$(echo "$line" | awk '{print $1}')
+    end=$(echo "$line" | awk '{print $2}')
+    output=$(echo "$line" | awk '{print $3}')
+    
+    # Split the video stream only, ignoring audio
+    ffmpeg -ss "$start" -to "$end" -i "$INPUT_FILE" -c:v copy -c:a copy "$output"
+done < "$TIMESTAMP_FILE"

--- a/Mac/timestamps.txt
+++ b/Mac/timestamps.txt
@@ -1,2 +1,0 @@
-00:00:00 23:59:59 name.mp3
-# leave a trailing line

--- a/Mac/timestamps_audio.txt
+++ b/Mac/timestamps_audio.txt
@@ -1,0 +1,2 @@
+00:00:00 23:59:59 name.mp3
+# leave a trailing line

--- a/Mac/timestamps_video.txt
+++ b/Mac/timestamps_video.txt
@@ -1,0 +1,2 @@
+00:00:00 00:03:12 name.mp4
+# leave a trailing line


### PR DESCRIPTION
# Overview

Includes a second script that will do the same splitting operation for video that is done for the audio. Additionally, removes the hardcoded input and timestamp file from the audio splitter and parameterizes the input.