### PR TITLE
Creates first five reminders plus documentation

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,52 @@
+name: CD - Tag, Changelog, Create Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        tags: true
+
+    - name: Check for Tags
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [ $(git tag | wc -l) -eq 0 ]; then
+          echo "No tags found, setting initial tag to v1.0.0"
+          git tag v1.0.0
+          git push --tags
+          echo "tag_setup=true" >> ${GITHUB_OUTPUT}
+        fi
+
+    - name: Generate Changelog
+      id: changelog
+      uses: mikepenz/release-changelog-builder-action@v4.2.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Bump Version
+      id: bump_version
+      uses: anothrNick/github-tag-action@1.67.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BUMP: minor
+        RELEASE_BRANCHES: main
+        WITH_V: true
+
+    - name: Create Release
+      uses: ncipollo/release-action@v1.14.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Release ${{ steps.bump_version.outputs.new_tag }}
+        tag: ${{ steps.bump_version.outputs.new_tag }}
+        body: ${{ steps.changelog.outputs.changelog }}

--- a/Mac/Reminders/README.md
+++ b/Mac/Reminders/README.md
@@ -1,0 +1,52 @@
+# Overview
+
+Each of these files is descriptively named and contains a simple bash script that echos a command and pipes it to `pbcopy`. Originally, this was a textfile on my desktop containing commands I used frequently and didn't want to keep reminding myself of. To see what commands are available, use `ls`, and then run `./<filename>.sh` to copy the command to your clipboard. Then, paste, populate, and run.
+
+All responsibility related to the use of these tools is assumed by anyone who uses them. This repo is shared under the GPL-3.0 license, indicating that the author does not assume any responsibility for how a given end user may use this material, or any consequences stemming from that use. Be responsible, be kind.
+
+### YT-DLP
+
+#### Prereq
+
+```shell
+brew install yt-dlp
+```
+
+#### yt-dlp_mp4FromChrome.sh
+
+Downloads a .mp4 file from a target URL, using the cookies in chrome.
+
+#### yt-dlp_MKVFromChrome.sh
+
+Downloads a .mkv file from a target URL, using the cookies in chrome.
+
+#### yt-dlp_MP3FromChrome.sh
+
+Downloads a .mp3 file from a target URL, using the cookies in chrome.
+
+### Archive Downloader
+
+#### Prereq
+
+[Link to Python project](https://github.com/john-corcoran/internetarchive-downloader)
+
+```shell
+$INTERNET_ARCHIVE_EMAIL
+$INTERNET_ARCHIVE_PASS
+```
+
+#### archiveDownloader_downloadListOfURLs.sh
+
+Uses `xargs` and `archive-org-downloader.py` to download each URL present in a file named `urls.txt` to `~/Downloads/`.
+
+### CURL
+
+#### Prereq
+
+```shell
+brew install curl
+```
+
+#### curl_hitEachInFile.sh
+
+Uses `xargs` and `curl` to hit each URL present in a file named `urls.txt` to `~/Downloads/`. Technically doesn't need to be a download target, though that was the designed use case. Uses four degrees of parallelism.

--- a/Mac/Reminders/archiveDownloader_downloadListOfURLs.sh
+++ b/Mac/Reminders/archiveDownloader_downloadListOfURLs.sh
@@ -1,0 +1,2 @@
+echo 'Copied to clipboard: cat urls.txt | xargs -I {} python archive-org-downloader.py -e "$INTERNET_ARCHIVE_EMAIL" -p "$INTERNET_ARCHIVE_PASS" -d ~/Downloads -u "{}"'
+echo 'cat urls.txt | xargs -I {} python archive-org-downloader.py -e "$INTERNET_ARCHIVE_EMAIL" -p "$INTERNET_ARCHIVE_PASS" -d ~/Downloads -u "{}"' | pbcopy

--- a/Mac/Reminders/curl_hitEachInFile.sh
+++ b/Mac/Reminders/curl_hitEachInFile.sh
@@ -1,0 +1,2 @@
+echo 'Copied to clipboard: cat urls.txt | xargs -n 1 -P 4 curl -O'
+echo 'cat urls.txt | xargs -n 1 -P 4 curl -O' | pbcopy

--- a/Mac/Reminders/yt-dlp_MKVFromChrome.sh
+++ b/Mac/Reminders/yt-dlp_MKVFromChrome.sh
@@ -1,0 +1,2 @@
+echo 'Copied to clipboard: yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --merge-output-format mkv --cookies-from-browser chrome ""'
+echo 'yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --merge-output-format mkv --cookies-from-browser chrome ""' | pbcopy

--- a/Mac/Reminders/yt-dlp_MP3FromChrome.sh
+++ b/Mac/Reminders/yt-dlp_MP3FromChrome.sh
@@ -1,0 +1,2 @@
+echo 'Copied to clipboard: yt-dlp -x --audio-format mp3 --cookies-from-browser chrome ""'
+echo 'yt-dlp -x --audio-format mp3 --cookies-from-browser chrome ""' | pbcopy

--- a/Mac/Reminders/yt-dlp_mp4FromChrome.sh
+++ b/Mac/Reminders/yt-dlp_mp4FromChrome.sh
@@ -1,0 +1,2 @@
+echo 'Copied to clipboard: yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome ""'
+echo 'yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome ""' | pbcopy


### PR DESCRIPTION
# Overview

This adds a new directory, `Reminders/`, which contains simple shell scripts that are descriptively named in the pattern `tool_function.sh`. Running `ls` in this directory will remind you of all the commands present of which you can be reminded, and running a given script echoes the command and pipes it to `pbcopy`. This replaces a text file on my desktop that I used to refer to frequently.

Additionally, I added `create-release.yaml` in this PR, which creates a simple tagging, changelog, and release CD.

# Testing

These are simple scripts, so I tested them locally.

```shell
~/Dropbox/Programming/Utilities/Mac/Reminders - ./yt-dlp_MKVFromChrome.sh
Copied to clipboard: yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --merge-output-format mkv --cookies-from-browser chrome ""
...
~/Dropbox/Programming/Utilities/Mac/Reminders - ./yt-dlp_MP3FromChrome.sh
Copied to clipboard: yt-dlp -x --audio-format mp3 --cookies-from-browser chrome ""
...
~/Dropbox/Programming/Utilities/Mac/Reminders - ./yt-dlp_mp4FromChrome.sh
Copied to clipboard: yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome ""
...
~/Dropbox/Programming/Utilities/Mac/Reminders - ./curl_hitEachInFile.sh 
Copied to clipboard: cat urls.txt | xargs -n 1 -P 4 curl -O
...
~/Dropbox/Programming/Utilities/Mac/Reminders - ./archiveDownloader_downloadListOfURLs.sh
Copied to clipboard: cat urls.txt | xargs -I {} python archive-org-downloader.py -e "$INTERNET_ARCHIVE_EMAIL" -p "$INTERNET_ARCHIVE_PASS" -d ~/Downloads -u "{}"
~/Dropbo
```