### PR TITLE
remove step checking for tags and add fetch-depth 0

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -15,18 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        tags: true
-
-    - name: Check for Tags
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        if [ $(git tag | wc -l) -eq 0 ]; then
-          echo "No tags found, setting initial tag to v1.0.0"
-          git tag v1.0.0
-          git push --tags
-          echo "tag_setup=true" >> ${GITHUB_OUTPUT}
-        fi
+        fetch-depth: 0
 
     - name: Generate Changelog
       id: changelog


### PR DESCRIPTION
# Overview

Amends the contents of `create-release.yaml` to fix the bugging step where it attempted to create tag `v1.0.0` multiple times.