### PR TITLE
Tested and working

### DIFF
--- a/Mac/Reminders/yt-dlp_mp4FromChrome.sh
+++ b/Mac/Reminders/yt-dlp_mp4FromChrome.sh
@@ -1,2 +1,2 @@
-echo 'Copied to clipboard: yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome ""'
-echo 'yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome ""' | pbcopy
+echo 'Copied to clipboard: yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome "$1"'
+echo 'yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome "$1"' | pbcopy

--- a/Mac/populate_reminder.sh
+++ b/Mac/populate_reminder.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Step 1: Trigger helper script, which fills the clipboard
+"$@"
+
+# Step 2: Grab from clipboard
+template=$(pbpaste)
+
+# Step 3: Replace $1, $2, ... with arguments passed AFTER the script
+shift  # Drop the helper script path
+arg_index=1
+
+for arg in "$@"; do
+  placeholder="\$$arg_index"
+  template="${template//$placeholder/$arg}"
+  ((arg_index++))
+done
+
+# Step 4: Copy result back to clipboard and print
+echo "$template" | tee >(pbcopy)


### PR DESCRIPTION
# Overview

Adds a new helper script that executes a reminder and populates it with an argument to simplify usage.

# Testing

```bash
Mac - $ bash populate_reminder.sh Reminders/yt-dlp_mp4FromChrome.sh https://example.com
Copied to clipboard: yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome "$1"
yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome "https://example.com"
Mac - $ yt-dlp -f "bv*[vcodec^=avc]+ba[ext=m4a]/b[ext=mp4]/b" --cookies-from-browser chrome "https://example.com"
```